### PR TITLE
Fix a problem when move at certain point, things will go wrong

### DIFF
--- a/KTOneFingerRotationGestureRecognizer.m
+++ b/KTOneFingerRotationGestureRecognizer.m
@@ -63,7 +63,15 @@
    CGPoint previousTouchPoint = [touch previousLocationInView:view];
    
    CGFloat angleInRadians = atan2f(currentTouchPoint.y - center.y, currentTouchPoint.x - center.x) - atan2f(previousTouchPoint.y - center.y, previousTouchPoint.x - center.x);
-   
+    if (fabs(angleInRadians) > 1) {
+        if (atan2(currentTouchPoint.y - center.y, currentTouchPoint.x - center.x) <0) {
+            angleInRadians = atan2(currentTouchPoint.y - center.y, currentTouchPoint.x - center.x) + 2*3.1415926 - atan2(previousTouchPoint.y - center.y, previousTouchPoint.x - center.x);
+            
+        } else if (atan2(currentTouchPoint.y - center.y, currentTouchPoint.x - center.x) >0) {
+            angleInRadians = -atan2(currentTouchPoint.y - center.y, currentTouchPoint.x - center.x) + 2*3.1415926 + atan2(previousTouchPoint.y - center.y, previousTouchPoint.x - center.x);
+            
+        }
+    }
    [self setRotation:angleInRadians];
 }
 


### PR DESCRIPTION
your way to implement it is to find the difference of the angle to the center of the view from the two touch points. However, when a new point is at left top circle and the old point is at the left down circle, the rotation this class will return will be about -2pi, which is not right.(this only happens if you swipe really slow in a clockwise direction). Same thing applies to the counterclockwise direction. My code added a check to those two situations and calculate the angle separately.
